### PR TITLE
Prepare 2.0.0-ballot for publication

### DIFF
--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -1,6 +1,6 @@
 All significant changes to this FHIR implementation guide will be documented on this page.  
 
-### v2.0.0-ballot
+### v2.0.0-ballot (2026-06-10)
 
 First version 
 

--- a/input/pagecontent/index.md
+++ b/input/pagecontent/index.md
@@ -5,6 +5,9 @@ This exchange format is established as a standard by the association eCH under t
 
 <div markdown="1" class="stu-note">
 
+This implementation guide is under STU ballot by [HL7 Switzerland](https://www.hl7.ch/) from August 4th, 2026 until September 30th, 2026.
+Please add your feedback via the 'Propose a change'-link in the footer.
+
 [Significant changes, open and closed issues.](changelog.html)
 
 </div>

--- a/publication-request.json
+++ b/publication-request.json
@@ -1,11 +1,11 @@
 {
   "package-id": "ch.fhir.ig.ch-ems",
-  "version": "2.1.0-ballot",
-  "path": "http://fhir.ch/ig/ch-ems/2.1.0-ballot",
+  "version": "2.0.0-ballot",
+  "path": "http://fhir.ch/ig/ch-ems/2.0.0-ballot",
   "mode": "milestone",
-  "status": "trial-use",
-  "sequence" : "STU",
-  "desc": "IVR STU",
-  "changes" : "changelog.html",
-  "first" : false
+  "status": "ballot",
+  "sequence": "STU 2",
+  "desc": "CH EMS STU 2 Ballot",
+  "changes": "changelog.html",
+  "first": false
 }

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ contact:
         use: work
 
 dependencies:
-  ch.fhir.ig.ch-core: current
+  ch.fhir.ig.ch-core: 7.0.0
   ch.fhir.ig.ch-term: 3.4.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ contact:
         use: work
 
 dependencies:
-  ch.fhir.ig.ch-core: 7.0.0
+  ch.fhir.ig.ch-core: 7.0.0-ballot
   ch.fhir.ig.ch-term: 3.4.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ status: active # draft | active | retired | unknown
 license: CC0-1.0
 copyright: CC0-1.0
 jurisdiction: urn:iso:std:iso:3166#CH
-date: 2026-06-10 # TODO before publication: check status and version of value sets
+date: 2026-06-12 # TODO before publication: check status and version of value sets
 version: 2.0.0-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2020+

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -24,7 +24,7 @@ contact:
         use: work
 
 dependencies:
-  ch.fhir.ig.ch-core: 7.0.x
+  ch.fhir.ig.ch-core: current
   ch.fhir.ig.ch-term: 3.4.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ status: active # draft | active | retired | unknown
 license: CC0-1.0
 copyright: CC0-1.0
 jurisdiction: urn:iso:std:iso:3166#CH
-date: 2026-06-09 # TODO before publication: check status and version of value sets
+date: 2026-06-10 # TODO before publication: check status and version of value sets
 version: 2.0.0-ballot
 fhirVersion: 4.0.1
 copyrightYear: 2020+
@@ -24,8 +24,8 @@ contact:
         use: work
 
 dependencies:
-  ch.fhir.ig.ch-core: current
-  ch.fhir.ig.ch-term: 3.3.x
+  ch.fhir.ig.ch-core: 7.0.x
+  ch.fhir.ig.ch-term: 3.4.x
   hl7.terminology.r4: 
     uri: http://terminology.hl7.org/ImplementationGuide/hl7.terminology
     version: 7.1.0 


### PR DESCRIPTION
Prepare CH EMS 2.0.0-ballot for publication.

Changes:
- sushi-config.yaml: date, dependencies (ch-core 7.0.x, ch-term 3.4.x)
- publication-request.json: fixed version from 2.1.0-ballot to 2.0.0-ballot, updated all fields
- index.md: added ballot notice
- changelog.md: added release date